### PR TITLE
init topFragmentState when TransactionHelper created to fix the bug that occurred when activity recreated

### DIFF
--- a/app/src/main/java/org/mozilla/focus/navigation/TransactionHelper.java
+++ b/app/src/main/java/org/mozilla/focus/navigation/TransactionHelper.java
@@ -254,6 +254,8 @@ class TransactionHelper implements DefaultLifecycleObserver {
 
         BackStackListener(TransactionHelper helper) {
             this.helper = helper;
+            // set up initial states
+            notifyTopFragment(helper.activity.getSupportFragmentManager());
         }
 
         @Override


### PR DESCRIPTION
fix #55
init `topFragmentState` when TransactionHelper created to fix the bug that occurred when activity recreated