### PR TITLE
Vincent/game/issue 261

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/content/games/ui/adapter/GameAdapterDelegate.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/games/ui/adapter/GameAdapterDelegate.kt
@@ -41,10 +41,10 @@ class GameViewHolder(
         val intent = Intent()
         intent.putExtra("gameType", gamesViewModel.selectedGame.type)
         if (gamesViewModel.canShare())
-            menu?.add(0, R.id.share, 0, R.string.game_contextmenu_share)?.setIntent(intent)
+            menu?.add(0, R.id.share, 0, R.string.gaming_vertical_menu_option_1)?.setIntent(intent)
         if (gamesViewModel.canCreateShortCut())
-            menu?.add(0, R.id.shortcut, 0, R.string.game_contextmenu_create_shortcut)?.setIntent(intent)
+            menu?.add(0, R.id.shortcut, 0, R.string.gaming_vertical_menu_option_2)?.setIntent(intent)
         if (gamesViewModel.canRemoveFromList())
-            menu?.add(0, R.id.remove, 0, R.string.game_contextmenu_remove_from_gamelist)?.setIntent(intent)
+            menu?.add(0, R.id.remove, 0, R.string.gaming_vertical_menu_option_3)?.setIntent(intent)
     }
 }


### PR DESCRIPTION
fix #261 

- root cause:

due to fragments in viewpager will all response to the context menu, so we need to find a solution to figure out which one is currently shown fragment.

 - Solutoin:

when creating context menu in viewholder, we insert an intent with selectedGameType; then we only response on the fragment which fits the gameType.