### PR TITLE
Set applicationId of preview build flavor to 'org.mozilla.rocket.beta' 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,9 +134,8 @@ android {
 
         preview {
             dimension "product"
-            applicationId "gro.allizom.zelda.beta"
-            applicationIdSuffix ""
-            versionNameSuffix ".nightly"
+            applicationIdSuffix ".beta"
+            versionNameSuffix ".beta"
         }
 
         // We can build with two engines: webkit or gecko

--- a/app/src/preview/res/values/strings.xml
+++ b/app/src/preview/res/values/strings.xml
@@ -3,6 +3,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
-    <string name="app_name" translatable="false">Firefox Lite Nightly</string>
-    <string name="app_name_private" translatable="false">Firefox Lite Nightly - Private browsing</string>
+    <string name="app_name" translatable="false">Firefox Lite Preview</string>
+    <string name="app_name_private" translatable="false">Firefox Lite Preview - Private browsing</string>
 </resources>


### PR DESCRIPTION
There will be a following PR to remove `beta` flavor.
Related to #281 