### PR TITLE
reduce ui testing freaky

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/BookmarksTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/BookmarksTest.java
@@ -116,7 +116,9 @@ public class BookmarksTest {
         // Tap menu
         AndroidTestUtils.tapHomeMenuButton();
         // Tap Bookmark button
-        onView(withId(R.id.menu_bookmark)).perform(click());
+        onView(withId(R.id.menu_bookmark))
+                .inRoot(RootMatchers.isDialog())
+                .perform(click());
         // Show "No Bookmarks" in bookmarks panel
         onView(withId(R.id.empty_view_container)).check(matches(isDisplayed()));
     }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ChangeLanguageTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ChangeLanguageTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.preference.Preference;
 import androidx.annotation.NonNull;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.uiautomator.UiDevice;
@@ -84,7 +85,9 @@ public class ChangeLanguageTest {
 
         // Tap menu -> settings
         AndroidTestUtils.tapHomeMenuButton();
-        onView(withId(R.id.menu_preferences)).perform(click());
+        onView(withId(R.id.menu_preferences))
+                .inRoot(RootMatchers.isDialog())
+                .perform(click());
 
         // Tap language
         Resources resources = activity.getResources();

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ClearCacheTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ClearCacheTest.java
@@ -2,6 +2,7 @@ package org.mozilla.focus.activity;
 
 import android.content.Intent;
 import androidx.annotation.Keep;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -58,7 +59,9 @@ public class ClearCacheTest {
         AndroidTestUtils.tapHomeMenuButton();
 
         // Tap clear cache
-        onView(withId(R.id.menu_delete)).perform(click());
+        onView(withId(R.id.menu_delete))
+                .inRoot(RootMatchers.isDialog())
+                .perform(click());
 
         // Check toast message "cache cleared"
         String msgClearCacheWoFormatter = AndroidTestUtils.removeStrFormatter(activityRule.getActivity().getResources().getString(R.string.message_cleared_cached));

--- a/app/src/androidTest/java/org/mozilla/focus/activity/DefaultBrowserTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DefaultBrowserTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.preference.Preference;
 import androidx.annotation.NonNull;
 import androidx.test.InstrumentationRegistry;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.filters.SdkSuppress;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -88,7 +89,9 @@ public class DefaultBrowserTest {
         AndroidTestUtils.tapHomeMenuButton();
 
         // Click on Settings
-        onView(withId(R.id.menu_preferences)).perform(click());
+        onView(withId(R.id.menu_preferences))
+                .inRoot(RootMatchers.isDialog())
+                .perform(click());
 
         // Click on "Default Browser" setting, this will brings up the Android system setting
         clickDefaultBrowserSetting(prefName);
@@ -168,7 +171,9 @@ public class DefaultBrowserTest {
         AndroidTestUtils.tapHomeMenuButton();
 
         // Click on Settings
-        onView(withId(R.id.menu_preferences)).perform(click());
+        onView(withId(R.id.menu_preferences))
+                .inRoot(RootMatchers.isDialog())
+                .perform(click());
 
         // Click on "Default Browser" setting, this will brings up the Android system setting
         clickDefaultBrowserSetting(prefName);

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MenuShareLinkTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MenuShareLinkTest.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 
 import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.GrantPermissionRule;
 
@@ -146,7 +147,9 @@ public class MenuShareLinkTest {
         AndroidTestUtils.tapHomeMenuButton();
 
         // Check share btn disabled
-        onView(new BottomBarRobot().menuBottomBarItemView(R.id.bottom_bar_share)).check(matches(not(isEnabled())));
+        onView(new BottomBarRobot().menuBottomBarItemView(R.id.bottom_bar_share))
+                .inRoot(RootMatchers.isDialog())
+                .check(matches(not(isEnabled())));
     }
 
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MenuTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MenuTest.java
@@ -8,6 +8,7 @@ package org.mozilla.focus.activity;
 import android.content.Intent;
 
 import androidx.annotation.Keep;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
 
@@ -57,7 +58,9 @@ public class MenuTest {
         AndroidTestUtils.tapHomeMenuButton();
 
         // check downloads,
-        onView(withId(R.id.menu_download)).check(matches(isDisplayed()));
+        onView(withId(R.id.menu_download))
+                .inRoot(RootMatchers.isDialog())
+                .check(matches(isDisplayed()));
 
         // check bookmarks
         onView(withId(R.id.menu_bookmark)).check(matches(isDisplayed()));

--- a/app/src/androidTest/java/org/mozilla/focus/activity/OnBoardingTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/OnBoardingTest.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import androidx.annotation.Keep;
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.IdlingRegistry;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -97,7 +98,10 @@ public class OnBoardingTest {
         AndroidTestUtils.tapHomeMenuButton();
 
         // Check if turbo mode is on
-        onView(withId(R.id.menu_turbomode)).check(matches(isDisplayed())).check(matches(isSelected()));
+        onView(withId(R.id.menu_turbomode))
+                .inRoot(RootMatchers.isDialog())
+                .check(matches(isDisplayed()))
+                .check(matches(isSelected()));
 
         // Close menu
         Espresso.pressBack();


### PR DESCRIPTION
add `.inRoot(RootMatchers.isDialog())` before checking views in popup menu